### PR TITLE
fix: [CHK-4144] add input validation to run_docker.sh

### DIFF
--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -4,11 +4,22 @@
 
 ENV=$1
 
+set -euo pipefail
+
 if [ -z "$ENV" ]
 then
   ENV="local"
   echo "No environment specified: local is used."
 fi
+
+case "$ENV" in
+  local|dev|uat|prod)
+    ;;
+  *)
+    echo "Error: Environment must be one of: local, dev, uat, prod"
+    exit 1
+    ;;
+esac
 
 pip3 install yq
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Added strict input validation in `docker/run_docker.sh`:
  - Enabled strict mode with `set -euo pipefail` to catch errors early.
  - Introduced a `case` statement to restrict `ENV` values to: `local`, `dev`, `uat`, or `prod`.

<!--- Describe your changes in detail -->

#### Motivation and Context
Previously, the script accepted any value (or no value) for the ENV argument, which could lead to misconfigurations or unintended behavior.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
